### PR TITLE
Don't pipe multiple streams into a single writable

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -87,10 +87,9 @@ WebRTC-RtpTransport enables these use cases by enabling applications to:
 ```javascript
 const pc = new RTCPeerConnection({encodedInsertableStreams: true});
 const rtpTransport = pc.createRtpTransport();
-pc.getSenders().forEach((sender) => {
-  sender.createEncodedStreams().readable.
+// Do custom packetization on the first sender
+pc.getSenders()[0].createEncodedStreams().readable.
       pipeThrough(createPacketizingTransformer()).pipeTo(rtpTransport.writable);
-});
 
 function createPacketizingTransformer() {
   return new TransformStream({


### PR DESCRIPTION
Fix for #15

Note: This fix is still based on the legacy accessor API, documented [here](https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/pull/111.html), rather than the standardized API, available here: https://w3c.github.io/webrtc-encoded-transform/