### PR TITLE
Add batch interfaces for reading RtpSents and RtpAcks

### DIFF
--- a/api-outline.md
+++ b/api-outline.md
@@ -77,10 +77,17 @@ partial interface RTCRtpReceiver {
 interface RTCRtpTransport {
   Promise<RTCRtpSendStream> addRtpSendStream(RTCRtpSendStreamInit);
   Promise<RTCRtpReceiveStream> addRtpReceiveStream(RTCRtpReceiveStreamInit);
-  attribute EventHandler onrtpsent;  // RtpSent
-  attribute EventHandler onrtpacksreceived;  // RtpAcks
+
   attribute EventHandler onpacketizedrtpavailable;  // No payload. Call readPacketizedRtp
   sequence<RTCRtpPacket> readPacketizedRtp(maxNumberOfPackets);
+
+  attribute EventHandler onsentrtp;  // No payload. Use readSentRtp
+  // Batch interface to read SentRtp notifications.
+  sequence<SentRtp> readSentRtp(long maxCount);
+
+  attribute EventHandler onreceivedrtpacks;  // No payload. Use readReceivedRtpAcks
+  // Batch interface to read RtpAcks as an alternative to onrtpacksreceived.
+  sequence<RtpAcks> readReceivedRtpAcks(long maxCount);
 
   readonly attribute unsigned long bandwidthEstimate;  // bps
   readonly attribute unsigned long allocatedBandwidth;  // bps

--- a/explainer-use-case-2.md
+++ b/explainer-use-case-2.md
@@ -19,6 +19,8 @@ Applications can do custom bandwidth estimation via:
 - Knowledge of when an application packet is not sent, and why.
 - Efficient control of when packets are sent, in order to do custom pacing and probing.
 
+Applications need to be be able to batch processing to run much less often than per-packet, to reduce overheads in high bandwidth situations, where packets are sent and received thousands of times per second.
+
 ## Examples
 
 ## Example 1: Custom BWE
@@ -26,15 +28,19 @@ Applications can do custom bandwidth estimation via:
 ```javascript
 const [pc, rtpTransport] = setupPeerConnectionWithRtpTransport();  // Custom
 const estimator = createBandwidthEstimator();  // Custom
-rtpTransport.onrtpsent = (rtpSent) => {
-    if (rtpSent.ackId) {
-        estimator.rememberRtpSent(rtpSent);
+rtpTransport.onsentrtp = () => {
+  for (const sentRtp of rtpTransport.readSentRtp(100)) {
+    if (sentRtp.ackId) {
+        estimator.rememberSentRtp(sentRtp);
     }
+  }
 }
-rtpTransport.onrtpacksreceived = (rtpAcks) => {
-    for (const rtpAck in rtpAcks.acks) {
-        const bwe = estimator.processReceivedAcks(rtpAck);
-        rtpTransport.customMaxBandwidth = bwe;
+rtpTransport.onreceivedrtpacks = () => {
+    for (const rtpAcks in rtpTransport.readReceivedRtpAcks(100)) {
+      for (const rtpAck in rtpAcks.acks) {
+          const bwe = estimator.processReceivedAcks(rtpAck);
+          rtpTransport.customMaxBandwidth = bwe;
+      }
     }
 }
 
@@ -84,6 +90,39 @@ async function pacePacketBatch() {
     await new Promise(resolve => {setTimeout(resolve, 20)});
   }
 }
+```
+
+## Example 3: Custom BWE with Batched processing
+
+```javascript
+const [pc, rtpTransport] = setupPeerConnectionWithRtpTransport();  // Custom
+const estimator = createBandwidthEstimator();  // Custom
+
+// Every 100ms, notify the estimator of all RTP packets sent.
+setInterval(() => {
+  // Read all synchronously available rtpSents in batches of 100.
+  while(true) {
+    let sentRtps = rtpTransport.readSentRtp(100);
+    if (sentRtps.length == 0) {
+      break;
+    }
+    sentRtps.forEach((sentRtp) => estimator.rememberRtpSent(sentRtp));
+  }
+}, 100);
+
+// Every 100ms, notify the estimator of all RTP acks received.
+setInterval(() => {
+  // Read all synchronously available RtpAcks in batches of 100.
+  while(true) {
+    let rtpAcks = rtpTransport.readReceivedRtpAcks(100);
+    if (rtpAcks.length == 0) {
+      break;
+    }
+    rtpAcks.forEach((ack) => estimator.processReceivedAcks(ack));
+  }
+  // Update bitrate estimations now that estimator is up to date.
+  doBitrateAllocationAndUpdateEncoders(estimator);  // Custom
+}, 100);
 ```
 
 ## Alternative designs considered


### PR DESCRIPTION
Add batch methods as discussed in #20.

Currently leaving the Events unchanged, as an alternative.