### PR TITLE
Resolve the indecisive attribute/getter on PeerConnection

### DIFF
--- a/explainer-use-case-1.md
+++ b/explainer-use-case-1.md
@@ -94,8 +94,8 @@ dictionary RtpHeaderExtensionInit {
 
 ```javascript
 partial interface PeerConnection {
-  // There may be an RtpTransport with no RtpSenders and no RtpReceivers
-  readonly attribute sequence<RtpTransport> getRtpTransports();
+  // There may be an RtpTransport with no RtpSenders and no RtpReceivers.
+  readonly attribute RtpTransport rtpTransport;
 }
 partial interface RtpSender {
   // shared between RtpSenders in the same BUNDLE group

--- a/explainer-use-case-1.md
+++ b/explainer-use-case-1.md
@@ -95,7 +95,7 @@ dictionary RtpHeaderExtensionInit {
 ```javascript
 partial interface PeerConnection {
   // There may be an RtpTransport with no RtpSenders and no RtpReceivers.
-  readonly attribute RtpTransport rtpTransport;
+  readonly attribute RtpTransport? rtpTransport;
 }
 partial interface RtpSender {
   // shared between RtpSenders in the same BUNDLE group


### PR DESCRIPTION
Picked an attribute, to match RTCPeerConnection.sctp, RTCRtpSender.transport etc

Also dropping the sequence, as I believe is happening in #34, following agreement in a discussion meeting. Note if we do have a sequence, [this can't be an attribute](https://webidl.spec.whatwg.org/#:~:text=The%20type%20of%20the%20attribute%2C%20after%20resolving%20typedefs%2C%20must%20not%20be%20a%20nullable%20or%20non%2Dnullable%20version%20of%20any%20of%20the%20following%20types%3A).