### PR TITLE
Automatic keep alive of local candidates.

### DIFF
--- a/api-outline.md
+++ b/api-outline.md
@@ -24,15 +24,19 @@ interface RtcTransport {
   // Largest allowed packet payload size.
   readonly attribute unsigned maxPacketsizeBytes;
 
+  // Will continuously gather host candidates.
+  void startGatheringHostCandidates();
+
   // Gathers local candidates using the specified STUN/TURN server. Promise
   // resolves when gathering is done.
   // TODO: Should there be timeout parameter as well?
   // TODO: STUN attributes?
-  // TODO: Gather host candidates, separate function or just null iceServer?
   promise<void> gatherCandidates(IceServer iceServer);
 
   // Triggers when a local candidate has been found.
-  attribute EventHandler oncandidate;
+  attribute EventHandler onlocalcandidategathered;
+  // Triggers when a local candidate has been removed (lost WIFI etc...).
+  attribute EventHandler onlocalcandidateremoved;
 
   // Tries to establish a path using the specified pair. The promise will either
   // return a probe result or some error. Can also be used to continuously
@@ -44,9 +48,6 @@ interface RtcTransport {
   // TODO: What RTT should be measured when using TURN, the TURN server or
   //       the other peer?
   promise<RtcProbeResult> probePath(CandidatePair);
-
-  // Triggers when a local candidate has been removed (lost WIFI etc...).
-  attribute EventHandler oncandidateremoved;
 
   // Triggers when the circuit-breaker kicks in.
   attribute EventHandler oncandidatedisabled;

--- a/api-outline.md
+++ b/api-outline.md
@@ -120,13 +120,28 @@ enum CandidateType {
   relay,
 }
 
-dictionary Candidate {
-  DOMString ufrag;
-  DOMString pwd;
-  DOMString address;
-  unsigned port;
-  CandidateType type;
-  unsigned networkCost;
+// Will keep local candidates alive by periodically sending either STUN binding
+// requests, or in the case of TURN, by sending refresh requests.
+interface LocalCandidate {
+  readonly DOMString ufrag;
+  readonly DOMString pwd;
+  readonly DOMString address;
+  readonly unsigned port;
+  readonly CandidateType type;
+  readonly unsigned networkCost;
+
+  // Stops sending keep alive packets. If this is a TURN candidate the TURN
+  // allocation will be released.
+  void release();
+};
+
+dictionary RemoteCandidate {
+  readonly DOMString ufrag;
+  readonly DOMString pwd;
+  readonly DOMString address;
+  readonly unsigned port;
+  readonly CandidateType type;
+  readonly unsigned networkCost;
 };
 
 dictionary RtcTransportConfig {
@@ -136,8 +151,8 @@ dictionary RtcTransportConfig {
 };
 
 dicitonary CandidatePair {
-  Candidate localCandidate;
-  Candidate remoteCandidate;
+  LocalCandidate localCandidate;
+  RemoteCandidate remoteCandidate;
 };
 
 dictionary RtcProbeResult {


### PR DESCRIPTION
There is currently no way of keeping a TURN allocation alive, so to fix that a `LocalCandidate` type can be used which has builtin functionality to periodically refresh the allocation. To keep thing "symmetrical" it will also send STUN pings for non-relay candidates.