### PR TITLE
Update Makefile to use spec-generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 index.html: index.bs
-	curl https://api.csswg.org/bikeshed/ -F file=@index.bs  > index.html
+	curl https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F type=bikeshed-spec > index.html
 
 check: index.bs
-	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F output=err
+	curl https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F type=bikeshed-spec -F output=messages


### PR DESCRIPTION
This updates the Makefile, which referenced the discontinued api.csswg.org/bikeshed HTTP API, to instead use https://www.w3.org/publications/spec-generator/.

I would note a few observations about this Makefile, which have me wondering whether it's presently unused:

- Currently `make index.html` does nothing because `index.html` is actively committed to the repository (not in `.gitignore`)
- If I run `make check` or remove `index.html` and test `make index.html`, bikeshed fails due to a trailing comma in JSON found in `index.bs`, which seems to have been that way for 2 years
- If I fix the JSON, I notice the output is missing a lot of content currently included in the ED