### PR TITLE
Separate IceFooInit Dictionaries and IceFoo interfaces

### DIFF
--- a/api-outline.md
+++ b/api-outline.md
@@ -105,7 +105,7 @@ interface RtcManualIceController {
   Promise<unsigned long> refreshRelayCandidate(LocalIceCandidate relayCandidate, unsigned long requestedLifetimeInSeconds);
 
   // Creates an IceCandidatePair that represents a possible network route.
-  IceCandidatePair createCandidatePair(LocalIceCandidate local, RemoteIceCandidate remote);
+  IceCandidatePair createCandidatePair(LocalIceCandidate local, RemoteIceCandidateInit remote);
 
   // Probes the candidate pair to check if it's (still) viable and what the RTT is.
   Promise<IceProbeResult> probeCandidatePair(IceCandidatePair candidatePair);
@@ -138,7 +138,7 @@ interface RtcAutomaticIceController {
 
   undefined gatherCandidates();
 
-  undefined AddRemoteCandidate(RemoteIceCandidate remoteCandidate);
+  undefined AddRemoteCandidate(RemoteIceCandidateInit remoteCandidate);
 
   // Triggers when a local candidate has been found (IceCandidateGatheredEvent). 
   attribute EventHandler oncandidategathered;
@@ -239,7 +239,17 @@ interface LocalIceCandidate {
   readonly attribute unsigned short networkCost;
 }; 
 
-dictionary RemoteIceCandidate {
+[Exposed=Window,Worker]
+interface RemoteIceCandidate {
+  readonly attribute DOMString ufrag;
+  readonly attribute DOMString pwd;
+  readonly attribute DOMString address;
+  readonly attribute unsigned short port;
+  readonly attribute IceCandidateType type;
+  readonly attribute unsigned short networkCost;
+}; 
+
+dictionary RemoteIceCandidateInit {
   required DOMString ufrag;
   required DOMString pwd;
   required DOMString address;

--- a/api-outline.md
+++ b/api-outline.md
@@ -90,7 +90,7 @@ interface RtcManualIceController {
   undefined gatherHostCandidates();
 
   // Gathers srflx candidates.
-  Promise<undefined> gatherSrflxCandidates(IceServer iceServer);
+  Promise<undefined> gatherSrflxCandidates(IceServerInit iceServer);
   // Sends a STUN ping to the IceServer used to discover this candidate, used
   // to keep the candidate (NAT binding) alive. Returns a boolean indicating
   // whether a successful STUN response was received or not.
@@ -99,7 +99,7 @@ interface RtcManualIceController {
   Promise<boolean> refreshSrflxCandidate(LocalIceCandidate localCandidate);
 
   // Gathers relay candidates.
-  Promise<undefined> gatherRelayCandidates(IceServer server, unsigned long requestedLifetimeInSeconds);
+  Promise<undefined> gatherRelayCandidates(IceServerInit server, unsigned long requestedLifetimeInSeconds);
   // Sends a STUN packet with a LIFETIME attribute included, used to extend the
   // TURN allocation. Returns the actual lifetime granted by the server.
   Promise<unsigned long> refreshRelayCandidate(LocalIceCandidate relayCandidate, unsigned long requestedLifetimeInSeconds);
@@ -134,7 +134,7 @@ An automatic ICE controller API
 ```javascript
 [Exposed=Window,Worker]
 interface RtcAutomaticIceController {
-  undefined SetIceServers(sequence<IceServer> servers);
+  undefined SetIceServers(sequence<IceServerInit> servers);
 
   undefined gatherCandidates();
 
@@ -216,11 +216,18 @@ dictionary RtcPacketReceived {
 Various ICE related helper types
 
 ```javascript
-dictionary IceServer {
+dictionary IceServerInit {
   required DOMString url;
   required DOMString username;
   required DOMString credentials;
 };
+
+[Exposed=Window,Worker]
+interface IceServer {
+  readonly attribute DOMString url;
+  readonly attribute DOMString username;
+  readonly attribute DOMString password;
+}; 
 
 enum IceCandidateType {
   "host",

--- a/index.bs
+++ b/index.bs
@@ -313,7 +313,7 @@ interface RtcManualIceController {
   Promise&lt;boolean&gt; refreshSrflxCandidate(LocalIceCandidate localCandidate);
   Promise&lt;undefined&gt; gatherRelayCandidates(IceServer server, unsigned long requestedLifetimeInSeconds);
   Promise&lt;unsigned long&gt; refreshRelayCandidate(LocalIceCandidate relayCandidate, unsigned long requestedLifetimeInSeconds);
-  IceCandidatePair createCandidatePair(LocalIceCandidate local, RemoteIceCandidate remote);
+  IceCandidatePair createCandidatePair(LocalIceCandidate local, RemoteIceCandidateInit remote);
   Promise&lt;IceProbeResult&gt; probeCandidatePair(IceCandidatePair candidatePair);
   attribute EventHandler oncandidategathered;
   attribute EventHandler oncandidateremoved;
@@ -363,7 +363,7 @@ interface RtcManualIceController {
 interface RtcAutomaticIceController {
   undefined SetIceServers(sequence&lt;IceServer&gt; servers);
   undefined gatherCandidates();
-  undefined AddRemoteCandidate(RemoteIceCandidate remoteCandidate);
+  undefined AddRemoteCandidate(RemoteIceCandidateInit remoteCandidate);
   attribute EventHandler oncandidategathered;
   attribute EventHandler oncandidateremoved;
   attribute EventHandler onmaxpayloadsizeupdate;
@@ -536,7 +536,17 @@ interface LocalIceCandidate {
 
 ## RemoteIceCandidate ## {#remoteicecandidate}
 <pre class="idl">
-dictionary RemoteIceCandidate {
+[Exposed=(Window,Worker)]
+interface RemoteIceCandidate {
+  readonly attribute DOMString ufrag;
+  readonly attribute DOMString pwd;
+  readonly attribute DOMString address;
+  readonly attribute unsigned short port;
+  readonly attribute IceCandidateType type;
+  readonly attribute unsigned short networkCost;
+};
+
+dictionary RemoteIceCandidateInit {
   required DOMString ufrag;
   required DOMString pwd;
   required DOMString address;

--- a/index.bs
+++ b/index.bs
@@ -484,6 +484,7 @@ dictionary IceServerInit {
 :: The credentials for authentication.
 
 <pre class="idl">
+[Exposed=(Window,Worker)]
 interface IceServer {
   readonly attribute DOMString url;
   readonly attribute DOMString username;

--- a/index.bs
+++ b/index.bs
@@ -309,9 +309,9 @@ Issue: Should there be any validation of the fingerprints? Is there a particular
 [Exposed=(Window,Worker)]
 interface RtcManualIceController {
   undefined gatherHostCandidates();
-  Promise&lt;undefined&gt; gatherSrflxCandidates(IceServer iceServer);
+  Promise&lt;undefined&gt; gatherSrflxCandidates(IceServerInit iceServer);
   Promise&lt;boolean&gt; refreshSrflxCandidate(LocalIceCandidate localCandidate);
-  Promise&lt;undefined&gt; gatherRelayCandidates(IceServer server, unsigned long requestedLifetimeInSeconds);
+  Promise&lt;undefined&gt; gatherRelayCandidates(IceServerInit server, unsigned long requestedLifetimeInSeconds);
   Promise&lt;unsigned long&gt; refreshRelayCandidate(LocalIceCandidate relayCandidate, unsigned long requestedLifetimeInSeconds);
   IceCandidatePair createCandidatePair(LocalIceCandidate local, RemoteIceCandidateInit remote);
   Promise&lt;IceProbeResult&gt; probeCandidatePair(IceCandidatePair candidatePair);
@@ -361,7 +361,7 @@ interface RtcManualIceController {
 <pre class="idl">
 [Exposed=(Window,Worker)]
 interface RtcAutomaticIceController {
-  undefined SetIceServers(sequence&lt;IceServer&gt; servers);
+  undefined SetIceServers(sequence&lt;IceServerInit&gt; servers);
   undefined gatherCandidates();
   undefined AddRemoteCandidate(RemoteIceCandidateInit remoteCandidate);
   attribute EventHandler oncandidategathered;
@@ -468,19 +468,35 @@ dictionary RtcPacketReceived {
 
 ## IceServer ## {#iceserver}
 <pre class="idl">
-dictionary IceServer {
+dictionary IceServerInit {
   required DOMString url;
   required DOMString username;
   required DOMString credentials;
 };
 </pre>
-: <dfn for="IceServer" dict-member>url</dfn>
+: <dfn for="IceServerInit" dict-member>url</dfn>
 :: The URL of the ICE server.
 
-: <dfn for="IceServer" dict-member>username</dfn>
+: <dfn for="IceServerInit" dict-member>username</dfn>
 :: The username used for credential verification.
 
-: <dfn for="IceServer" dict-member>credentials</dfn>
+: <dfn for="IceServerInit" dict-member>credentials</dfn>
+:: The credentials for authentication.
+
+<pre class="idl">
+interface IceServer {
+  readonly attribute DOMString url;
+  readonly attribute DOMString username;
+  readonly attribute DOMString credentials;
+};
+</pre>
+: <dfn for="IceServer" attribute>url</dfn>
+:: The URL of the ICE server.
+
+: <dfn for="IceServer" attribute>username</dfn>
+:: The username used for credential verification.
+
+: <dfn for="IceServer" attribute>credentials</dfn>
 :: The credentials for authentication.
 
 ## IceCandidateType ## {#icecandidatetype}

--- a/index.bs
+++ b/index.bs
@@ -545,7 +545,27 @@ interface RemoteIceCandidate {
   readonly attribute IceCandidateType type;
   readonly attribute unsigned short networkCost;
 };
+</pre>
+: <dfn for="RemoteIceCandidate" attribute>ufrag</dfn>
+:: Remote ICE user fragment.
 
+: <dfn for="RemoteIceCandidate" attribute>pwd</dfn>
+:: Remote ICE password.
+
+: <dfn for="RemoteIceCandidate" attribute>address</dfn>
+:: Remote IP Address of the candidate.
+
+: <dfn for="RemoteIceCandidate" attribute>port</dfn>
+:: Remote Port of the candidate.
+
+: <dfn for="RemoteIceCandidate" attribute>type</dfn>
+:: The remote candidate type.
+
+: <dfn for="RemoteIceCandidate" attribute>networkCost</dfn>
+:: The remote costs associated with network route utilization.
+
+<pre class="idl">
+[Exposed=(Window,Worker)]
 dictionary RemoteIceCandidateInit {
   required DOMString ufrag;
   required DOMString pwd;
@@ -555,22 +575,24 @@ dictionary RemoteIceCandidateInit {
   unsigned short networkCost;
 };
 </pre>
-: <dfn for="RemoteIceCandidate" dict-member>ufrag</dfn>
+
+
+: <dfn for="RemoteIceCandidateInit" dict-member>ufrag</dfn>
 :: Remote ICE user fragment.
 
-: <dfn for="RemoteIceCandidate" dict-member>pwd</dfn>
+: <dfn for="RemoteIceCandidateInit" dict-member>pwd</dfn>
 :: Remote ICE password.
 
-: <dfn for="RemoteIceCandidate" dict-member>address</dfn>
+: <dfn for="RemoteIceCandidateInit" dict-member>address</dfn>
 :: Remote IP Address of the candidate.
 
-: <dfn for="RemoteIceCandidate" dict-member>port</dfn>
+: <dfn for="RemoteIceCandidateInit" dict-member>port</dfn>
 :: Remote Port of the candidate.
 
-: <dfn for="RemoteIceCandidate" dict-member>type</dfn>
+: <dfn for="RemoteIceCandidateInit" dict-member>type</dfn>
 :: The remote candidate type.
 
-: <dfn for="RemoteIceCandidate" dict-member>networkCost</dfn>
+: <dfn for="RemoteIceCandidateInit" dict-member>networkCost</dfn>
 :: The remote costs associated with network route utilization.
 
 ## IceCandidatePair ## {#icecandidatepair-section}


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-rtptransport/pull/119.html" title="Last updated on Jun 30, 2026, 1:26 PM UTC (10b76db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-rtptransport/119/0090e25...10b76db.html" title="Last updated on Jun 30, 2026, 1:26 PM UTC (10b76db)">Diff</a>